### PR TITLE
avoid deoptimization

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -30,13 +30,14 @@ function parse(input) {
   let equalityIndex = -1;
   let shouldDecode = false;
   let hasPlus = false;
+  const lastIndex = input.length;
 
   // Have a boundary of input.length + 1 to access last pair inside the loop.
-  for (let i = 0; i < input.length + 1; i++) {
-    let c = input.charCodeAt(i);
+  for (let i = 0; i < lastIndex + 1; i++) {
+    let c = (i !== lastIndex && input.charCodeAt(i)) || 0;
 
     // Handle '&' and end of line to pass the current values to result
-    if (c === 38 || isNaN(c)) {
+    if (c === 38 || c === 0) {
       // Check if the current range consist of a single key
       if (equalityIndex <= startingIndex) {
         key = input.slice(startingIndex + 1, i);


### PR DESCRIPTION
deoptigate reports an out of bounds error resulting in a eager bailout. My benchmarks are on node 18.

My benchmark:

```js
'use strict'

const Benchmark = require('benchmark');
const fastQueryString = require("./lib/index.js");
var suite = new Benchmark.Suite;

suite.add('fastQueryString', function() {
  fastQueryString.parse("hello=world&foo=bar&foo=baz")
})
// add listeners
.on('cycle', function(event) {
  console.log(String(event.target));
})
.on('complete', function() {
  console.log('Fastest is ' + this.filter('fastest').map('name'));
})
.run();
```

before:

```sh
fastQueryString x 3,002,304 ops/sec ±0.48% (94 runs sampled)
Fastest is fastQueryString
```


after:

```sh
fastQueryString x 3,661,458 ops/sec ±0.76% (94 runs sampled)
Fastest is fastQueryString
```