### PR TITLE
use -1 instead of 0 as lastIndex indicator

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -34,10 +34,10 @@ function parse(input) {
 
   // Have a boundary of input.length + 1 to access last pair inside the loop.
   for (let i = 0; i < lastIndex + 1; i++) {
-    let c = (i !== lastIndex && input.charCodeAt(i)) || 0;
+    let c = (i !== lastIndex && input.charCodeAt(i)) || -1;
 
     // Handle '&' and end of line to pass the current values to result
-    if (c === 38 || c === 0) {
+    if (c === 38 || c === -1) {
       // Check if the current range consist of a single key
       if (equalityIndex <= startingIndex) {
         key = input.slice(startingIndex + 1, i);


### PR DESCRIPTION
this is a follow up to #2 

I thought about it. Probably somebody is crazy enough to use %00 in his/her query and then it would stop parsing to early. 

Performance seems to be still the same.