### PR TITLE
ci: update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,6 +20,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -29,7 +36,7 @@ jobs:
           run_install: true
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Linter
         run: pnpm run format:ci


### PR DESCRIPTION
This PR:

-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout
-   Adds `--ignore-scripts` option to `pnpm install` command to protect against malicious scripts in dependencies
-   Enables `concurrency` in `ci.yml`; see [related docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency), this allows a subsequently queued workflow run to interrupt previous runs in PRs