### PR TITLE
docs(readme): remove legacy npm arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast query-string parser to replace the legacy `node:querystring` parse function
 ### Installation
 
 ```
-npm i --save fast-querystring
+npm i fast-querystring
 ```
 
 ### Features


### PR DESCRIPTION
Removes `--save` npm arg, which is legacy and hasn't been needed since pre-npm 5.x