### PR TITLE
chore(.npmignore): remove `LICENSE`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,3 @@ benchmark
 .idea
 .github
 rome.json
-LICENSE


### PR DESCRIPTION
`LICENSE` is always included in published module, see https://docs.npmjs.com/cli/v8/using-npm/developers#keeping-files-out-of-your-package