### PR TITLE
chore(.npmignore): remove `node_modules`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-node_modules
 .editorconfig
 package-lock.json
 coverage


### PR DESCRIPTION
Always ignored by npm publish, see https://docs.npmjs.com/cli/v8/using-npm/developers#keeping-files-out-of-your-package