### PR TITLE
perf: 15 % better perf for number to string, avoid intermediate Math.abs, use implicit number to string coercion

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -13,8 +13,9 @@ function getAsPrimitive(value) {
   } else if (type === "boolean") {
     return value ? "true" : "false";
   } else if (type === "number" && Number.isFinite(value)) {
-    if (Math.abs(value) < 1e21) return value.toString();
-    return encodeString(value.toString());
+    return value < 1e21
+      ? value.toString()
+      : encodeString(value.toString())
   }
 
   return "";

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -13,9 +13,7 @@ function getAsPrimitive(value) {
   } else if (type === "boolean") {
     return value ? "true" : "false";
   } else if (type === "number" && Number.isFinite(value)) {
-    return value < 1e21
-      ? value.toString()
-      : encodeString(value.toString())
+    return value < 1e21 ? value.toString() : encodeString(value.toString());
   }
 
   return "";

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -13,7 +13,7 @@ function getAsPrimitive(value) {
   } else if (type === "boolean") {
     return value ? "true" : "false";
   } else if (type === "number" && Number.isFinite(value)) {
-    return value < 1e21 ? value.toString() : encodeString(value.toString());
+    return value < 1e21 ? "" + value : encodeString("" + value);
   }
 
   return "";


### PR DESCRIPTION
The reason why we do Math.abs is because 1e21.toString() returns "1e+21". + gets encoded but - not. So there is no good reason to do a Math.abs call. We only need to know if the number is bigger or equal than 1e21.

We could probably optimize also the >= 1e21 case because we only need to replace the +. But I guess that case is actually neglectable, because we are already bigger than Number.MAX_SAFE_INTEGER.

My benchmarks showed that doing 

```js
const tmp = value.toString(); 
const pos = tmp.indexOf('+'); 
return value.slice(0, pos) + '%2B' + value.slice(pos + 1);
```

could be faster than calling encodeString.