### PR TITLE
fix: encode large negative numbers in stringify

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -11,7 +11,7 @@ function getAsPrimitive(value) {
   } else if (type === "bigint" || type === "boolean") {
     return "" + value;
   } else if (type === "number" && Number.isFinite(value)) {
-    return value < 1e21 ? "" + value : encodeString("" + value);
+    return Math.abs(value) < 1e21 ? "" + value : encodeString("" + value);
   }
 
   return "";

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -94,6 +94,7 @@ test("should coerce numbers to string", () => {
   assert.strictEqual(qs.stringify({ foo: -72.42 }), "foo=-72.42");
   assert.strictEqual(qs.stringify({ foo: Number.NaN }), "foo=");
   assert.strictEqual(qs.stringify({ foo: 1e21 }), "foo=1e%2B21");
+  assert.strictEqual(qs.stringify({ foo: -1e21 }), "foo=-1e%2B21");
   assert.strictEqual(qs.stringify({ foo: Number.POSITIVE_INFINITY }), "foo=");
 });
 


### PR DESCRIPTION
Numbers with magnitude >= 1e21 are serialized by JavaScript in exponential notation (e.g. -1e+22). The previous check only compared value < 1e21, so negative numbers in this range skipped encodeString and left a raw '+' in the output, which query string parsers decode as a space and corrupt the round-trip. Use Math.abs to apply the threshold symmetrically for positive and negative values.